### PR TITLE
Make staged joins mandatory

### DIFF
--- a/src/riak_core.erl
+++ b/src/riak_core.erl
@@ -56,7 +56,7 @@ stop(Reason) ->
 %% @doc Join the ring found on the specified remote node
 %%
 join(Node) ->
-    join(Node, true).
+    join(Node, false).
 
 %% @doc Join the remote cluster without automatically claiming ring
 %%      ownership. Used to stage a join in the newer plan/commit


### PR DESCRIPTION
Added missing change for commit [1](https://github.com/riak-core-lite/riak_core_lite/commit/5e557c4add720610a0b648add071c8a4a667243b) and [2](https://github.com/riak-core-lite/riak_core_lite/commit/cff3ad09ec92641a002762ca45d1a7dff213fdeb) regarding mandatory staged joins.

@marianoguerra This breaks your tutorial video, as `make devrel-cluster-plan` and `make devrel-cluster-commit` are now mandatory (should be mandatory before, but was not). I'll merge and release `v0.10.0` once you're ready.

This doesnt' prevent the gossip protocol to rejoin a ring, autojoin is still possible internally.