### PR TITLE
Vnode simplification

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Build upon the essence of Riak KV's core with an up-to-date, modular and extensi
 ![Build](https://img.shields.io/badge/build-rebar3%203.15.1-brightgreen.svg)
 
 [![Hex pm](https://img.shields.io/hexpm/v/riak_core_lite.svg)](https://hex.pm/packages/riak_core_lite)
-![Erlang CI](https://github.com/albsch/riak_core_lite/workflows/Erlang%20CI/badge.svg)
+![Erlang CI](https://github.com/riak-core-lite/riak_core_lite/workflows/Erlang%20CI/badge.svg)
 [![Coverage Status](https://coveralls.io/repos/github/riak-core-lite/riak_core_lite/badge.svg?branch=master)](https://coveralls.io/github/riak-core-lite/riak_core_lite?branch=master)
 
 

--- a/include/riak_core_vnode.hrl
+++ b/include/riak_core_vnode.hrl
@@ -1,4 +1,4 @@
--type sender_type() :: fsm | server | raw.
+-type sender_type() :: fsm | server .
 
 -type sender() :: {sender_type(), reference() | tuple() | ignore_ref , pid()} | ignore.
 

--- a/include/riak_core_vnode.hrl
+++ b/include/riak_core_vnode.hrl
@@ -1,16 +1,6 @@
 -type sender_type() :: fsm | server | raw.
 
--type sender() :: {sender_type(), reference() | tuple(),
-                   pid()} |
-                  {fsm, undefined, pid()} |
-                  {server, undefined, undefined} |
-                  ignore.
-
-                                           %% TODO: Double-check that these special cases are kosher
-
-                                              % what are these special cases and what is the reference used for??
-
- % special case in riak_core_vnode_master.erl
+-type sender() :: {sender_type(), reference() | tuple() | ignore_ref , pid()} | ignore.
 
 -type partition() :: chash:index_as_int().
 

--- a/src/riak_core_send_msg.erl
+++ b/src/riak_core_send_msg.erl
@@ -23,34 +23,13 @@
 -module(riak_core_send_msg).
 
 -export([reply_unreliable/2,
-         cast_unreliable/2,
          send_event_unreliable/2]).
-
--ifdef(TEST).
-
--ifdef(PULSE).
-
--compile(export_all).
-
--compile({parse_transform, pulse_instrument}).
-
--compile({pulse_replace_module,
-          [{gen_fsm, pulse_gen_fsm},
-           {gen_fsm_compat, pulse_gen_fsm},
-           {gen_server, pulse_gen_server}]}).
-
--endif.
-
--endif.
 
 %% NOTE: We'ed peeked inside gen_server.erl's guts to see its internals.
 reply_unreliable({To, Tag}, Reply) ->
     bang_unreliable(To, {Tag, Reply});
 reply_unreliable(To, Reply) ->
     bang_unreliable(To, Reply).
-
-cast_unreliable(Dest, Request) ->
-    bang_unreliable(Dest, {'$gen_cast', Request}).
 
 %% NOTE: We'ed peeked inside gen_fsm.erl's guts to see its internals.
 send_event_unreliable({global, _Name} = GlobalTo,

--- a/src/riak_core_send_msg.erl
+++ b/src/riak_core_send_msg.erl
@@ -46,7 +46,9 @@
 
 %% NOTE: We'ed peeked inside gen_server.erl's guts to see its internals.
 reply_unreliable({To, Tag}, Reply) ->
-    bang_unreliable(To, {Tag, Reply}).
+    bang_unreliable(To, {Tag, Reply});
+reply_unreliable(To, Reply) ->
+    bang_unreliable(To, Reply).
 
 cast_unreliable(Dest, Request) ->
     bang_unreliable(Dest, {'$gen_cast', Request}).

--- a/src/riak_core_send_msg.erl
+++ b/src/riak_core_send_msg.erl
@@ -24,8 +24,7 @@
 
 -export([reply_unreliable/2,
          cast_unreliable/2,
-         send_event_unreliable/2,
-         bang_unreliable/2]).
+         send_event_unreliable/2]).
 
 -ifdef(TEST).
 

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -382,12 +382,12 @@ send_command_after(Time, Request) ->
 %%
 -spec reply(sender(), term()) -> any().
 
-reply({fsm, undefined, From}, Reply) ->
+reply({fsm, ignore_ref, From}, Reply) ->
     riak_core_send_msg:send_event_unreliable(From, Reply);
 reply({fsm, Ref, From}, Reply) ->
     riak_core_send_msg:send_event_unreliable(From,
                                              {Ref, Reply});
-reply({server, undefined, From}, Reply) ->
+reply({server, ignore_ref, From}, Reply) ->
     riak_core_send_msg:reply_unreliable(From, Reply);
 reply({server, Ref, From}, Reply) ->
     riak_core_send_msg:reply_unreliable(From, {Ref, Reply});

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -41,7 +41,7 @@
          terminate/3,
          code_change/4]).
 
--export([reply/2, monitor/1]).
+-export([reply/2]).
 
 -export([get_mod_index/1,
          get_modstate/1,
@@ -392,18 +392,6 @@ reply({server, ignore_ref, From}, Reply) ->
 reply({server, Ref, From}, Reply) ->
     riak_core_send_msg:reply_unreliable(From, {Ref, Reply});
 reply(ignore, _Reply) -> ok.
-
-%% @doc Set up a monitor for the pid named by a {@type sender()} vnode
-%% argument.  If `Sender' was the atom `ignore', this function sets up
-%% a monitor on `self()' in order to return a valid (if useless)
-%% monitor reference.
--spec monitor(Sender :: sender()) -> Monitor ::
-                                         reference().
-monitor({fsm, _, From}) ->
-    erlang:monitor(process, From);
-monitor({server, _, {Pid, _Ref}}) ->
-    erlang:monitor(process, Pid);
-monitor(ignore) -> erlang:monitor(process, self()).
 
 %% ========================
 %% ========

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -391,8 +391,6 @@ reply({server, ignore_ref, From}, Reply) ->
     riak_core_send_msg:reply_unreliable(From, Reply);
 reply({server, Ref, From}, Reply) ->
     riak_core_send_msg:reply_unreliable(From, {Ref, Reply});
-reply({raw, Ref, From}, Reply) ->
-    riak_core_send_msg:bang_unreliable(From, {Ref, Reply});
 reply(ignore, _Reply) -> ok.
 
 %% @doc Set up a monitor for the pid named by a {@type sender()} vnode
@@ -401,13 +399,10 @@ reply(ignore, _Reply) -> ok.
 %% monitor reference.
 -spec monitor(Sender :: sender()) -> Monitor ::
                                          reference().
-
 monitor({fsm, _, From}) ->
     erlang:monitor(process, From);
 monitor({server, _, {Pid, _Ref}}) ->
     erlang:monitor(process, Pid);
-monitor({raw, _, From}) ->
-    erlang:monitor(process, From);
 monitor(ignore) -> erlang:monitor(process, self()).
 
 %% ========================

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -318,39 +318,39 @@ handoff_data(VNode, MsgData, VNodeTimeout) ->
 %% send_all_state_event
 %% =========================
 
-%% #5
+%% #4.1
 set_forwarding(VNode, ForwardTo) ->
     gen_fsm_compat:send_all_state_event(VNode,
                                         {set_forwarding, ForwardTo}).
 
-%% #6
+%% #4.2
 trigger_handoff(VNode, TargetIdx, TargetNode) ->
     gen_fsm_compat:send_all_state_event(VNode,
                                         {trigger_handoff,
                                          TargetIdx,
                                          TargetNode}).
 
-%% #7
+%% #4.3
 trigger_handoff(VNode, TargetNode) ->
     gen_fsm_compat:send_all_state_event(VNode,
                                         {trigger_handoff, TargetNode}).
 
-%% #8
+%% #4.4
 trigger_delete(VNode) ->
     gen_fsm_compat:send_all_state_event(VNode,
                                         trigger_delete).
 
-%% #11 - riak_core_vnode_manager - handle_vnode_event
+%% #4.5 - riak_core_vnode_manager - handle_vnode_event
 cast_finish_handoff(VNode) ->
     gen_fsm_compat:send_all_state_event(VNode,
                                         finish_handoff).
 
-%% #12 - riak_core_vnode_manager - handle_vnode_event
+%% #4.6 - riak_core_vnode_manager - handle_vnode_event
 cancel_handoff(VNode) ->
     gen_fsm_compat:send_all_state_event(VNode,
                                         cancel_handoff).
 
-%% #15 - riak_core_vnode_master - handle_call
+%% #4.7 - riak_core_vnode_master - handle_call
 send_all_proxy_req(VNode, Req) ->
     gen_fsm_compat:send_all_state_event(VNode, Req).
 
@@ -358,7 +358,7 @@ send_all_proxy_req(VNode, Req) ->
 %% send_event_after
 %% =========================
 
-%% #10
+%% #5
 %% Sends a command to the FSM that called it after Time
 %% has passed.
 -spec send_command_after(integer(),
@@ -385,8 +385,8 @@ send_command_after(Time, Request) ->
 reply({fsm, ignore_ref, From}, Reply) ->
     riak_core_send_msg:send_event_unreliable(From, Reply);
 reply({fsm, Ref, From}, Reply) ->
-    riak_core_send_msg:send_event_unreliable(From,
-                                             {Ref, Reply});
+    riak_core_send_msg:send_event_unreliable(From, {Ref, Reply});
+
 reply({server, ignore_ref, From}, Reply) ->
     riak_core_send_msg:reply_unreliable(From, Reply);
 reply({server, Ref, From}, Reply) ->
@@ -1525,6 +1525,7 @@ pool_death_test() ->
     exit(Pid, normal),
     wait_for_process_death(Pid),
     meck:validate(test_pool_mod),
-    meck:validate(test_vnode).
+    meck:validate(test_vnode),
+    error_logger:tty(true).
 
 -endif.

--- a/src/riak_core_vnode.erl
+++ b/src/riak_core_vnode.erl
@@ -1526,6 +1526,8 @@ pool_death_test() ->
     wait_for_process_death(Pid),
     meck:validate(test_pool_mod),
     meck:validate(test_vnode),
+    % TODO why is a short sleep needed to swallow crash message
+    timer:sleep(10),
     error_logger:tty(true).
 
 -endif.

--- a/test/worker_pool_test.erl
+++ b/test/worker_pool_test.erl
@@ -77,7 +77,7 @@ deadlock_test() ->
                                                         {worker_init, self()},
                                                     receive continue -> ok end
                                             end,
-                                            {raw, 1, self()}),
+                                            {server, 1, self()}),
     CoordinatorLoop ! {wait_for_worker, self()},
     receive continue -> ok end,
     riak_core_vnode_worker_pool:handle_work(Pool,
@@ -86,7 +86,7 @@ deadlock_test() ->
                                                         {ready_to_crash},
                                                     erlang:error(-1)
                                             end,
-                                            {raw, 1, self()}),
+                                            {server, 1, self()}),
     % now we have to wait a bit
     % because handle_work is a cast and there is no way to check when it's in the queue
     timer:sleep(50),
@@ -98,7 +98,7 @@ deadlock_test() ->
                                                     CoordinatorLoop !
                                                         finish_test
                                             end,
-                                            {raw, 1, self()}),
+                                            {server, 1, self()}),
     receive finish_test -> ok end,
     unlink(Pool),
     ok = riak_core_vnode_worker_pool:stop(Pool, normal),
@@ -116,7 +116,7 @@ simple_reply_worker_pool() ->
                                                      timer:sleep(10),
                                                      1 / (N rem 2)
                                              end,
-                                             {raw, N, self()})
+                                             {server, N, self()})
      || N <- lists:seq(1, 10)],
     timer:sleep(200),
     %% make sure we got all replies
@@ -138,7 +138,7 @@ simple_noreply_worker_pool() ->
                                                      timer:sleep(10),
                                                      1 / (N rem 2)
                                              end,
-                                             {raw, N, self()})
+                                             {server, N, self()})
      || N <- lists:seq(1, 10)],
     timer:sleep(200),
     %% make sure that the non-crashing work calls receive timeouts
@@ -172,7 +172,7 @@ shutdown_pool_worker_finish_success() ->
                                                []),
     riak_core_vnode_worker_pool:handle_work(Pool,
                                             fun () -> timer:sleep(50) end,
-                                            {raw, 1, self()}),
+                                            {server, 1, self()}),
     unlink(Pool),
     ok = riak_core_vnode_worker_pool:shutdown_pool(Pool,
                                                    100),
@@ -188,7 +188,7 @@ shutdown_pool_force_timeout() ->
                                                []),
     riak_core_vnode_worker_pool:handle_work(Pool,
                                             fun () -> timer:sleep(100) end,
-                                            {raw, 1, self()}),
+                                            {server, 1, self()}),
     unlink(Pool),
     {error, vnode_shutdown} =
         riak_core_vnode_worker_pool:shutdown_pool(Pool, 50),
@@ -204,7 +204,7 @@ shutdown_pool_duplicate_calls() ->
                                                []),
     riak_core_vnode_worker_pool:handle_work(Pool,
                                             fun () -> timer:sleep(100) end,
-                                            {raw, 1, self()}),
+                                            {server, 1, self()}),
     unlink(Pool),
     %% request shutdown a bit later a second time
     spawn_link(fun () ->


### PR DESCRIPTION
Simplified `vnode` module.

* Categorized api
* Removed special cases in `vnode_req` type
* Restricted vnode reply access to `fsm` and `vnode_master` (i.e. `server`) only
* Removed monitor api
* Tracking proper branch now in README